### PR TITLE
feat: add pages for GitLab CI/CD, S3 client, and PDF export

### DIFF
--- a/apps/nextjs/src/app/(hcode)/gitlab/page.tsx
+++ b/apps/nextjs/src/app/(hcode)/gitlab/page.tsx
@@ -1,0 +1,17 @@
+import { CodeBlock } from "@acme/ui/code-block";
+
+export default function Page() {
+  return (
+    <div>
+      <div>
+        <div>Using GitLab CI/CD with a GitHub repository</div>
+        <CodeBlock>
+          {`
+          https://docs.gitlab.com/ee/ci/ci_cd_for_external_repos/github_integration.html
+          Connect with personal access token
+      `}
+        </CodeBlock>
+      </div>
+    </div>
+  );
+}

--- a/apps/nextjs/src/app/(hcode)/nextjs/page.tsx
+++ b/apps/nextjs/src/app/(hcode)/nextjs/page.tsx
@@ -1,0 +1,18 @@
+import { CodeBlock } from "@acme/ui/code-block";
+
+export default function Page() {
+  return (
+    <div>
+      <div>
+        <div>Init project</div>
+      </div>
+      <div>Preview</div>
+      <CodeBlock>
+        {`
+          1. Create new repo
+          2. Clone repo
+      `}
+      </CodeBlock>
+    </div>
+  );
+}

--- a/apps/nextjs/src/app/(hcode)/react/pdf/page.tsx
+++ b/apps/nextjs/src/app/(hcode)/react/pdf/page.tsx
@@ -1,0 +1,151 @@
+import { CodeBlock } from "@acme/ui/code-block";
+
+export default function Page() {
+  return (
+    <div>
+      <div>
+        <div>Calculate page break html</div>
+        <div>
+          https://github.com/parallax/jsPDF/issues/2615#issuecomment-1600371956
+        </div>
+      </div>
+      <div>Preview</div>
+      <CodeBlock>
+        {`
+          const pdfBlob = pdf.output("blob");
+          const pdfURL = URL.createObjectURL(pdfBlob);
+          window.open(pdfURL);
+      `}
+      </CodeBlock>
+
+      <div>
+        <div>html2canvas-pro</div>
+        <div>vite.config.ts</div>
+        <CodeBlock>
+          {`
+            export default defineConfig({
+              resolve: {
+                alias: {
+                  html2canvas: path.resolve(
+                    __dirname,
+                    "node_modules/html2canvas-pro",
+                  ),
+                },
+              },
+            });
+          `}
+        </CodeBlock>
+      </div>
+
+      <div>
+        <div>with html2canvas</div>
+        <CodeBlock>
+          {`
+const handleExportPDF = async () => {
+    const contentElement = contentRef.current;
+    if (!contentElement) return;
+
+    const pdf = new jsPDF("p", "mm", "a4");
+    const padding = 10;
+    const imgWidth = 210 - padding * 2;
+    const pageHeight = 297;
+    let currentPageHeight = padding;
+
+    const pageBreaks: { start: number; end: number }[] = [];
+    let startOffset = 0;
+    const recursive = (element: HTMLElement) => {
+      try {
+        if (element.className.includes("_page-break")) {
+          pageBreaks.push({
+            start: startOffset,
+            end:
+              element.getBoundingClientRect().top -
+              contentElement.getBoundingClientRect().top,
+          });
+          startOffset =
+            element.getBoundingClientRect().top -
+            contentElement.getBoundingClientRect().top;
+        }
+        if (element.children.length > 0) {
+          for (const elm of element.children) {
+            recursive(elm as HTMLElement);
+          }
+        }
+      } catch {
+        //
+      }
+    };
+    recursive(contentElement);
+    pageBreaks.push({
+      start: pageBreaks.at(-1)?.end ?? 0,
+      end: contentElement.clientHeight,
+    });
+
+    const mainCanvas = await html2canvas(contentElement, {
+      useCORS: true,
+      allowTaint: true,
+      scale: 2,
+    });
+
+    for (const section of pageBreaks) {
+      const canvas = document.createElement("canvas");
+      const sectionHeight = section.end - section.start;
+      canvas.width = mainCanvas.width;
+      canvas.height = sectionHeight * 2; // scale = 2
+
+      const ctx = canvas.getContext("2d");
+      ctx?.drawImage(
+        mainCanvas,
+        0,
+        section.start * 2,
+        mainCanvas.width,
+        sectionHeight * 2,
+        0,
+        0,
+        mainCanvas.width,
+        sectionHeight * 2,
+      );
+
+      const imgData = canvas.toDataURL("image/png");
+      const imgHeight = (canvas.height * imgWidth) / canvas.width;
+
+      if (currentPageHeight + imgHeight > pageHeight - padding) {
+        pdf.addPage();
+        currentPageHeight = padding;
+      }
+
+      pdf.addImage(
+        imgData,
+        "PNG",
+        padding,
+        currentPageHeight,
+        imgWidth,
+        imgHeight,
+      );
+      currentPageHeight += imgHeight;
+    }
+
+    setGenerating(false);
+    return pdf;
+  };
+
+`}
+        </CodeBlock>
+      </div>
+      <div>
+        <div>keep render diff width not change current width</div>
+        <CodeBlock>
+          {`
+<div
+            style={{
+              position: "absolute",
+            }}
+          >
+<div ref={contentRef}>...</div>
+</div>
+          `}
+        </CodeBlock>
+      </div>
+    </div>
+  );
+}

--- a/apps/nextjs/src/app/(hcode)/react/s3/page.tsx
+++ b/apps/nextjs/src/app/(hcode)/react/s3/page.tsx
@@ -1,0 +1,37 @@
+import { CodeBlock } from "@acme/ui/code-block";
+
+export default function Page() {
+  return (
+    <div>
+      <div>
+        <div>s3Client</div>
+        <CodeBlock>
+          {`
+export const createS3Client = () => {
+  const client = new S3Client({
+    forcePathStyle: true,
+    // region: env.VITE_APP_SUPABASE_REGION,
+    region: "ap-northeast-1",
+    endpoint: env.VITE_APP_SUPABASE_URL + "/storage/v1/s3",
+    credentials: async () => {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      return {
+        accessKeyId: env.VITE_APP_SUPABASE_URL.slice(8).replace(
+          ".supabase.co",
+          "",
+        ),
+        secretAccessKey: env.VITE_APP_SUPABASE_ANON_KEY,
+        sessionToken: session?.access_token,
+      };
+    },
+  });
+  return client;
+};
+      `}
+        </CodeBlock>
+      </div>
+    </div>
+  );
+}

--- a/apps/nextjs/src/app/(hcode)/react/select/page.tsx
+++ b/apps/nextjs/src/app/(hcode)/react/select/page.tsx
@@ -1,0 +1,36 @@
+import { CodeBlock } from "@acme/ui/code-block";
+
+export default function Page() {
+  return (
+    <div>
+      <div>
+        <div>Dropdown Render (Footer)</div>
+        <CodeBlock>
+          {`
+dropdownRender={(menu) => {
+                  return (
+                    <>
+                      {menu}
+                      <Divider className="mb-1 mt-0" />
+                      <div className="mx-1 mb-1">
+                        <ButtonAdd
+                          className="w-full font-normal"
+                          variant="ghost"
+                          primary={false}
+                          srOnly={false}
+                          onClick={() => {
+                            setPeriodAddModalOpen(true);
+                          }}
+                        >
+                          Add period
+                        </ButtonAdd>
+                      </div>
+                    </>
+                  );
+                }}
+      `}
+        </CodeBlock>
+      </div>
+    </div>
+  );
+}

--- a/apps/nextjs/src/app/(hcode)/react/table/page.tsx
+++ b/apps/nextjs/src/app/(hcode)/react/table/page.tsx
@@ -1,0 +1,21 @@
+import { CodeBlock } from "@acme/ui/code-block";
+
+const temporaryData = [
+  {
+    id: "1",
+  },
+];
+export default function Page() {
+  return (
+    <div>
+      <div>
+        <div>Toolbar</div>
+        <CodeBlock>
+          {`
+          const isFiltered = table.getState().columnFilters.length > 0;
+      `}
+        </CodeBlock>
+      </div>
+    </div>
+  );
+}

--- a/apps/nextjs/src/app/(hcode)/react/xlsx/page.tsx
+++ b/apps/nextjs/src/app/(hcode)/react/xlsx/page.tsx
@@ -1,0 +1,37 @@
+import { CodeBlock } from "@acme/ui/code-block";
+
+export default function Page() {
+  return (
+    <div>
+      <div>
+        <div>Export</div>
+        <CodeBlock>
+          {`
+      const table = document.querySelector("#invoice-items-table");
+        const workbook = XLSX.utils.table_to_book(table, {
+          sheet: "Sheet 1",
+        });
+        const worksheet = workbook.Sheets["Sheet 1"]!;
+
+        const csv = XLSX.utils.sheet_to_csv(worksheet);
+      `}
+        </CodeBlock>
+      </div>
+
+      <div>
+        <div>Download</div>
+        <CodeBlock>
+          {`
+const blob = new Blob([csv], { type: "text/csv" });
+const url = URL.createObjectURL(blob);
+        const link = document.createElement("a");
+        link.href = url;
+        link.download = "data.csv";
+        link.click();
+        URL.revokeObjectURL(url);
+      `}
+        </CodeBlock>
+      </div>
+    </div>
+  );
+}

--- a/apps/nextjs/src/app/(hcode)/turbo/page.tsx
+++ b/apps/nextjs/src/app/(hcode)/turbo/page.tsx
@@ -1,0 +1,20 @@
+import { CodeBlock } from "@acme/ui/code-block";
+
+export default function Page() {
+  return (
+    <div>
+      <div>
+        <div>
+          × failed to connect to daemon ╰─▶ server is unavailable: channel
+          closed
+        </div>
+        <CodeBlock>
+          {`
+turbo daemon clean
+};
+      `}
+        </CodeBlock>
+      </div>
+    </div>
+  );
+}

--- a/apps/nextjs/src/app/(hcode)/xpath/page.tsx
+++ b/apps/nextjs/src/app/(hcode)/xpath/page.tsx
@@ -1,0 +1,20 @@
+import { CodeBlock } from "@acme/ui/code-block";
+
+export default function Page() {
+  return (
+    <div>
+      <div>
+        <div>by Text</div>
+        <CodeBlock>
+          {`
+timeline_button_elm = findElement(
+                    driver,
+                    By.XPATH,
+                    '//a[text()="Timeline"]',
+                )
+      `}
+        </CodeBlock>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Create new pages for GitLab CI/CD integration, S3 client setup, 
and PDF export functionality. Each page includes relevant code 
blocks to demonstrate usage. These additions enhance the 
documentation and provide practical examples for users.