### PR TITLE
feat(theme): add OKLCH color conversion and display

### DIFF
--- a/@acme/utils/src/color.ts
+++ b/@acme/utils/src/color.ts
@@ -1,15 +1,14 @@
-export const hexToRgb = (hex: string) => {
-  // Loại bỏ dấu "#" từ chuỗi hex
-  hex = hex.replace(/^#/, "");
-
-  // Chia chuỗi thành các thành phần màu RGB
-  const bigint = Number.parseInt(hex, 16);
-  const r = (bigint >> 16) & 255;
-  const g = (bigint >> 8) & 255;
-  const b = bigint & 255;
-
-  return { r, g, b };
-};
+export function hexToRgb(hex: string): { r: number; g: number; b: number } {
+  const match = /^#?([\da-f]{2})([\da-f]{2})([\da-f]{2})$/i.exec(hex);
+  if (!match) {
+    throw new Error("Invalid HEX color.");
+  }
+  return {
+    r: Number.parseInt(match[1]!, 16),
+    g: Number.parseInt(match[2]!, 16),
+    b: Number.parseInt(match[3]!, 16),
+  };
+}
 
 // Hàm chuyển đổi mã màu hex sang HSL
 export const hexToHsl = (hex: string) => {
@@ -53,3 +52,57 @@ export const hexToHsl = (hex: string) => {
   // to %
   return { h, s: Math.round(s * 100), l: Math.round(l * 100) };
 };
+
+function rgbToOklch({ r, g, b }: { r: number; g: number; b: number }): {
+  l: number;
+  c: number;
+  h: number;
+} {
+  // Normalize RGB to [0, 1]
+  r /= 255;
+  g /= 255;
+  b /= 255;
+
+  // Convert RGB to linear light
+  const linearize = (c: number) =>
+    c <= 0.040_45 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+  const lr = linearize(r);
+  const lg = linearize(g);
+  const lb = linearize(b);
+
+  // Convert linear RGB to XYZ
+  const x = lr * 0.412_456_4 + lg * 0.357_576_1 + lb * 0.180_437_5;
+  const y = lr * 0.212_672_9 + lg * 0.715_152_2 + lb * 0.072_175;
+  const z = lr * 0.019_333_9 + lg * 0.119_192 + lb * 0.950_304_1;
+
+  // Convert XYZ to LAB
+  const refX = 0.950_47;
+  const refY = 1;
+  const refZ = 1.088_83;
+
+  const fx =
+    x / refX > 0.008_856 ? Math.cbrt(x / refX) : (7.787 * x) / refX + 16 / 116;
+  const fy =
+    y / refY > 0.008_856 ? Math.cbrt(y / refY) : (7.787 * y) / refY + 16 / 116;
+  const fz =
+    z / refZ > 0.008_856 ? Math.cbrt(z / refZ) : (7.787 * z) / refZ + 16 / 116;
+
+  const l = 116 * fy - 16;
+  const a = 500 * (fx - fy);
+  const b_ = 200 * (fy - fz);
+
+  // Convert LAB to OKLCH
+  const c = Math.hypot(a, b_);
+  const h = Math.atan2(b_, a) * (180 / Math.PI);
+
+  return {
+    l: l / 100, // Lightness (normalized to [0, 1])
+    c, // Chroma
+    h: h >= 0 ? h : h + 360, // Hue (adjusted to [0, 360])
+  };
+}
+
+export function hexToOklch(hex: string): { l: number; c: number; h: number } {
+  const rgb = hexToRgb(hex);
+  return rgbToOklch(rgb);
+}

--- a/apps/nextjs/src/app/app/[lang]/(dashboard)/theme/page.tsx
+++ b/apps/nextjs/src/app/app/[lang]/(dashboard)/theme/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { generate } from "@ant-design/colors";
+import Color from "colorjs.io";
 
 import { CodeBlock } from "@acme/ui/code-block";
 import { Input } from "@acme/ui/input";
@@ -57,6 +58,7 @@ export default function ThemePage() {
           setInput({ ...input, backgroundColor: e.target.value })
         }
       />
+      <div>To HSL</div>
       <CodeBlock language="css">
         {palette
           .map((c, index) => {
@@ -79,6 +81,47 @@ export default function ThemePage() {
             return `--${input.slug}-${
               index === palette.length - 1 ? 950 : (index + 1) * 100
             }: ${hsl.h} ${hsl.s}% ${hsl.l}%;`;
+          })
+          .join("\n")}
+      </CodeBlock>
+      {darkPalete.map((c, index) => (
+        <div key={index} style={{ color: c }}>
+          {c}
+        </div>
+      ))}
+
+      <div>To OKLCH</div>
+      <CodeBlock language="css">
+        {palette
+          .map((c, index) => {
+            const oklch = new Color(c).to("oklch");
+            const value = oklch
+              .toString({ precision: 4 })
+              .replace("oklch(", "")
+              .slice(0, -1);
+
+            return `--${input.slug}-${
+              index === palette.length - 1 ? 950 : (index + 1) * 100
+            }: ${value};`;
+          })
+          .join("\n")}
+      </CodeBlock>
+      {palette.map((c, index) => (
+        <div key={index} style={{ color: c }}>
+          {c}
+        </div>
+      ))}
+      <CodeBlock language="css">
+        {darkPalete
+          .map((c, index) => {
+            const oklch = new Color(c).to("oklch");
+            const value = oklch
+              .toString({ precision: 4 })
+              .replace("oklch(", "")
+              .slice(0, -1);
+            return `--${input.slug}-${
+              index === palette.length - 1 ? 950 : (index + 1) * 100
+            }: ${value};`;
           })
           .join("\n")}
       </CodeBlock>


### PR DESCRIPTION
Implement OKLCH conversion in the theme. 
Add functionality convert and display color 
in both OKLCH and HSL formats. Update color utility 
functions to support RGB to OKLCH conversion. 
Enhance user experience by providing clear color 
representation in the UI.